### PR TITLE
adicionado width ao header para que o campo de busca fique centralizado

### DIFF
--- a/src/pages/Home/style.css
+++ b/src/pages/Home/style.css
@@ -13,6 +13,7 @@
 }
 #page-home .content header{
     margin: 48px 0 0;
+    width: 100%;
 }
 #page-home .content header img{
 position: absolute;


### PR DESCRIPTION
O elemento header ocupava apenas a largura de seu conteúdo e não era afetado pelo `justify-content: center;` do `display: flex;` da div de busca.